### PR TITLE
Add C++ and Rust language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Modernised Emacs configuration targeting Emacs 29/30. Highlights:
 The configuration keeps user customisations in `custom.el`. Feel free to edit
 `init.el` to suit your workflow—the file is organised into clearly labelled
 sections for easy navigation. Use `C-c C-i` inside Emacs to jump straight to the
-configuration. This key chord lives in the user-reserved `C-c` control prefix
-and intentionally repurposes the seldom used `C-c TAB` slot.
+configuration; this user-reserved control-prefix binding simply reuses the
+seldom-used `C-c TAB` slot that Emacs aliases to `C-c C-i` across environments.
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,30 @@
 .emacs.d
 ========
 
-Emacs configuration.
+Modernised Emacs configuration targeting Emacs 29/30. Highlights:
+
+* Uses `use-package` with the latest GNU, NonGNU and MELPA archives.
+* Ships with Vertico/Orderless/Consult for a fast, minimal completion stack.
+* Enables quality-of-life defaults such as relative line numbers, project
+  integration, on-the-fly linting and LSP (via `eglot`).
+* Ships first-class language support for Python, Go, Rust (with rust-analyzer)
+  and modern C/C++ (via clangd).
+
+### Getting started
+
+1. Ensure you are running Emacs 29.1 or newer (native compilation is enabled
+   automatically when available).
+2. Clone this repository into `~/.emacs.d` (back up any existing configuration
+   first).
+3. Launch Emacs; the required packages will be downloaded on the first run.
+
+The configuration keeps user customisations in `custom.el`. Feel free to edit
+`init.el` to suit your workflow—the file is organised into clearly labelled
+sections for easy navigation. Use `C-c I` inside Emacs to jump straight to the
+configuration.
+
+### FAQ
+
+#### What replaced `ido-ubiquitous`?
+
+`ido-ubiquitous` was renamed to [`ido-completing-read+`](https://github.com/DarwinAwardWinner/ido-completing-read-plus). This configuration opts for Vertico/Orderless/Consult instead, offering a more powerful completing-read experience out of the box.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Modernised Emacs configuration targeting Emacs 29/30. Highlights:
 
 The configuration keeps user customisations in `custom.el`. Feel free to edit
 `init.el` to suit your workflow—the file is organised into clearly labelled
-sections for easy navigation. Use `C-c I` inside Emacs to jump straight to the
-configuration.
+sections for easy navigation. Use `C-c C-i` inside Emacs to jump straight to the
+configuration. This key chord lives in the user-reserved `C-c` control prefix
+and intentionally repurposes the seldom used `C-c TAB` slot.
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Modernised Emacs configuration targeting Emacs 29/30. Highlights:
 * Uses `use-package` with the latest GNU, NonGNU and MELPA archives.
 * Ships with Vertico/Orderless/Consult for a fast, minimal completion stack.
 * Enables quality-of-life defaults such as relative line numbers, project
-  integration, on-the-fly linting and LSP (via `eglot`).
+  integration, on-the-fly linting and LSP (via `eglot` + `flycheck-eglot`).
 * Ships first-class language support for Python, Go, Rust (with rust-analyzer)
   and modern C/C++ (via clangd).
 

--- a/init.el
+++ b/init.el
@@ -180,6 +180,10 @@
 (use-package flycheck
   :hook (prog-mode . flycheck-mode))
 
+(use-package flycheck-eglot
+  :after (flycheck eglot)
+  :hook (eglot-managed-mode . flycheck-eglot-mode))
+
 (use-package lua-mode
   :mode ("\\.lua\\'" . lua-mode))
 

--- a/init.el
+++ b/init.el
@@ -193,6 +193,9 @@
   :custom
   (python-shell-interpreter "python3"))
 
+(use-package go-mode
+  :mode ("\\.go\\'" . go-mode))
+
 (use-package clojure-mode)
 
 (use-package scala-mode

--- a/init.el
+++ b/init.el
@@ -278,7 +278,7 @@ previous frame state so we can restore it when toggling back."
   "Open this init file."
   (interactive)
   (find-file (expand-file-name "init.el" user-emacs-directory)))
-(global-set-key (kbd "C-c C-e") #'open-init-file)
+(global-set-key (kbd "C-c C-i") #'open-init-file)
 
 ;; -------------------------------------------------------------------
 ;; Final setup

--- a/init.el
+++ b/init.el
@@ -119,8 +119,6 @@
 ;; Packages
 ;; -------------------------------------------------------------------
 
-(use-package better-defaults)
-
 (use-package which-key
   :hook (after-init . which-key-mode)
   :custom

--- a/init.el
+++ b/init.el
@@ -1,110 +1,284 @@
-;;
-;; Package manager settings
-;;
+;;; init.el --- Personal Emacs configuration -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; A lightweight, batteries-included configuration that embraces the
+;; modern Emacs 29/30 ecosystem.  The goal is to provide sensible
+;; defaults for day-to-day editing while keeping the file approachable
+;; for future tweaks.
+
+;;; Code:
+
+;; -------------------------------------------------------------------
+;; Package manager setup
+;; -------------------------------------------------------------------
 
 (require 'package)
-(add-to-list 'package-archives
-             '("melpa" . "https://melpa.org/packages/")
-             ;; '("marmalade" . "http://marmalade-repo.org/packages/")
-             )
-(package-initialize)
+(setq package-archives
+      '(("gnu"    . "https://elpa.gnu.org/packages/")
+        ("nongnu" . "https://elpa.nongnu.org/nongnu/")
+        ("melpa"  . "https://melpa.org/packages/")))
 
-(when (not package-archive-contents)
+(setq package-native-compile t)
+
+(unless (bound-and-true-p package--initialized)
+  (package-initialize))
+
+(unless package-archive-contents
   (package-refresh-contents))
 
-(defvar installed-packages '(better-defaults
-                             paredit
-                             idle-highlight-mode
-                             ido-ubiquitous
-                             fill-column-indicator
-                             find-file-in-project
-                             smex
-                             company
-                             clojure-mode
-                             scala-mode
-                             python-mode
-                             lua-mode
-                             auctex)
-  "Emacs packages to be installed if they aren't already.")
+(unless (package-installed-p 'use-package)
+  (package-install 'use-package))
 
-(dolist (p installed-packages)
-  (when (not (package-installed-p p))
-    (package-install p)))
+(require 'use-package)
+(setq use-package-always-ensure t
+      use-package-expand-minimally t
+      use-package-compute-statistics t)
 
-;; We don't want custom messing with this file
-(setq custom-file "~/.emacs.d/custom.el")
+;; Keep customisations out of this file and load them if present.
+(setq custom-file (expand-file-name "custom.el" user-emacs-directory))
+(when (file-exists-p custom-file)
+  (load custom-file 'noerror 'nomessage))
 
+;; -------------------------------------------------------------------
+;; Core UI/UX tweaks
+;; -------------------------------------------------------------------
 
-;;
-;; Frame appearance
-;;
-(menu-bar-mode -1)
-(tool-bar-mode -1)
-(if window-system
-  (scroll-bar-mode -1))
+(setq inhibit-startup-screen t
+      initial-scratch-message nil
+      ring-bell-function #'ignore
+      native-comp-async-report-warnings-errors 'silent)
+
+(dolist (mode '(menu-bar-mode tool-bar-mode scroll-bar-mode))
+  (when (fboundp mode)
+    (funcall mode -1)))
+
+(global-hl-line-mode 1)
+(column-number-mode 1)
+(which-function-mode 1)
+(display-time-mode 1)
+(setq display-time-default-load-average nil)
+
+(setq display-line-numbers-type 'relative)
+(dolist (hook '(prog-mode-hook text-mode-hook conf-mode-hook))
+  (add-hook hook #'display-line-numbers-mode))
+(dolist (mode '(vterm-mode-hook eshell-mode-hook shell-mode-hook term-mode-hook))
+  (add-hook mode (lambda () (display-line-numbers-mode 0))))
+
 (show-paren-mode 1)
-(transient-mark-mode 1)
-(add-hook 'find-file-hook (lambda ()
-                            (linum-mode 1)
-                            (line-number-mode -1)))
-(setq inhibit-startup-screen t)
-
-
-;; Fullscreen mode, bound to F11
-(defun toggle-fullscreen (&optional f)
-  (interactive)
-  (let ((current-value (frame-parameter nil 'fullscreen)))
-    (set-frame-parameter nil 'fullscreen
-                         (if (equal 'fullboth current-value)
-                             (if (boundp 'old-fullscreen) old-fullscreen nil)
-                           (progn (setq old-fullscreen current-value)
-                                  'fullboth)))))
-(global-set-key [f11] 'toggle-fullscreen)
-
-
-;; ido mode
-(ido-mode t)
-
-
-;; column marker
-(add-hook 'c-mode-hook 'fci-mode)
-(add-hook 'c++-mode-hook 'fci-mode)
-(add-hook 'python-mode-hook 'fci-mode)
-(setq fci-rule-width 1)
-(setq fci-rule-column 80)
-
-
-;; whitespace, which function, column number, deletion
-(which-function-mode)
+(when (fboundp 'pixel-scroll-precision-mode)
+  (pixel-scroll-precision-mode 1))
+(save-place-mode 1)
+(recentf-mode 1)
+(savehist-mode 1)
+(global-auto-revert-mode 1)
+(electric-pair-mode 1)
 (delete-selection-mode 1)
-(setq column-number-mode t)
-(setq whitespace-line-column 160)
 
+(setq-default fill-column 80
+              sentence-end-double-space nil)
+(when (fboundp 'display-fill-column-indicator-mode)
+  (setq-default display-fill-column-indicator-column 80)
+  (dolist (hook '(prog-mode-hook text-mode-hook conf-mode-hook))
+    (add-hook hook #'display-fill-column-indicator-mode)))
 
-;;
+;; -------------------------------------------------------------------
 ;; Editing behaviour
-;;
-(setq-default sh-basic-offset 4)
-(setq-default c-basic-offset 4)
-(setq-default indent-tabs-mode nil)
-(setq x-select-enable-clipboard t)
-(setq backup-directory-alist '(("." . "~/.emacs.d/backups")))
+;; -------------------------------------------------------------------
 
+(setq-default indent-tabs-mode nil
+              tab-width 4
+              sh-basic-offset 4
+              c-basic-offset 4
+              python-indent-offset 4
+              create-lockfiles nil
+              make-backup-files nil)
 
-;; scons
-(setq auto-mode-alist
-      (cons '("SConstruct" . python-mode) auto-mode-alist))
-(setq auto-mode-alist
-      (cons '("SConscript" . python-mode) auto-mode-alist))
+(setq backup-directory-alist
+      `(("." . ,(expand-file-name "backups" user-emacs-directory))))
+(setq auto-save-file-name-transforms
+      `((".*" ,(expand-file-name "auto-save/" user-emacs-directory) t)))
+(make-directory (expand-file-name "auto-save" user-emacs-directory) t)
+(make-directory (expand-file-name "backups" user-emacs-directory) t)
 
-;; Torch
-(add-to-list
- 'auto-mode-alist
- '("\\.th$" . lua-mode))
+(setq x-select-enable-clipboard t
+      kill-do-not-save-duplicates t
+      vc-follow-symlinks t)
 
+;; Recognise additional file types.
+(add-to-list 'auto-mode-alist '("SConstruct"  . python-mode))
+(add-to-list 'auto-mode-alist '("SConscript" . python-mode))
+(add-to-list 'auto-mode-alist '("\\.th\\'"     . lua-mode))
 
-;; no pretty fns
-(remove-hook 'clojure-mode-hook 'esk-pretty-fn)
+;; -------------------------------------------------------------------
+;; Packages
+;; -------------------------------------------------------------------
 
-;; company-mode
-(add-hook 'after-init-hook 'global-company-mode)
+(use-package better-defaults)
+
+(use-package which-key
+  :hook (after-init . which-key-mode)
+  :custom
+  (which-key-idle-delay 0.3)
+  (which-key-max-display-columns 5))
+
+(use-package vertico
+  :init
+  (vertico-mode)
+  :custom
+  (vertico-cycle t))
+
+(use-package orderless
+  :init
+  (setq completion-styles '(orderless basic)
+        completion-category-overrides '((file (styles partial-completion)))))
+
+(use-package marginalia
+  :hook (after-init . marginalia-mode))
+
+(use-package consult
+  :bind (("C-s" . consult-line)
+         ("C-x b" . consult-buffer)
+         ("M-y" . consult-yank-pop)
+         ([remap switch-to-buffer] . consult-buffer)))
+
+(use-package embark
+  :bind
+  ("C-;" . embark-act)
+  :custom
+  (embark-indicators
+   '(embark-minimal-indicator
+     embark-highlight-indicator
+     embark-isearch-highlight-indicator)))
+
+(use-package embark-consult
+  :after (embark consult)
+  :hook (embark-collect-mode . consult-preview-at-point-mode))
+
+(use-package company
+  :hook (after-init . global-company-mode)
+  :custom
+  (company-idle-delay 0.05)
+  (company-minimum-prefix-length 1)
+  (company-show-numbers t)
+  (company-tooltip-align-annotations t))
+
+(use-package paredit
+  :hook ((emacs-lisp-mode . paredit-mode)
+         (lisp-mode       . paredit-mode)
+         (clojure-mode    . paredit-mode)))
+
+(use-package rainbow-delimiters
+  :hook (prog-mode . rainbow-delimiters-mode))
+
+(use-package magit
+  :commands (magit-status))
+
+(use-package flycheck
+  :hook (prog-mode . flycheck-mode))
+
+(use-package lua-mode
+  :mode ("\\.lua\\'" . lua-mode))
+
+(use-package python
+  :ensure nil
+  :mode ("\\.py\\'" . python-mode)
+  :custom
+  (python-shell-interpreter "python3"))
+
+(use-package clojure-mode)
+
+(use-package scala-mode
+  :interpreter ("scala" . scala-mode))
+
+(use-package auctex)
+
+(use-package yaml-mode
+  :mode ("\\.ya?ml\\'" . yaml-mode))
+
+(use-package markdown-mode
+  :mode ("\\.md\\'" . gfm-mode)
+  :custom
+  (markdown-command "pandoc"))
+
+(use-package cc-mode
+  :ensure nil
+  :mode (("\\.c\\'"   . c-mode)
+         ("\\.h\\'"   . c-or-c++-mode)
+         ("\\.hpp\\'" . c++-mode)
+         ("\\.cc\\'"  . c++-mode)
+         ("\\.cpp\\'" . c++-mode)
+         ("\\.cxx\\'" . c++-mode))
+  :custom
+  (c-default-style '((c-mode    . "linux")
+                     (c++-mode  . "llvm")
+                     (java-mode . "java")
+                     (other     . "gnu"))))
+
+(use-package rust-mode
+  :mode ("\\.rs\\'" . rust-mode)
+  :hook (rust-mode . (lambda ()
+                       (setq-local fill-column 100)))
+  :custom
+  (rust-format-on-save t))
+
+(use-package eglot
+  :ensure nil
+  :hook ((python-mode . eglot-ensure)
+         (go-mode     . eglot-ensure))
+  :config
+  (dolist (hook '(c-mode-hook c++-mode-hook c-ts-mode-hook c++-ts-mode-hook
+                  rust-mode-hook rust-ts-mode-hook))
+    (add-hook hook #'eglot-ensure))
+  (add-to-list 'eglot-server-programs '((c-mode c++-mode c-ts-mode c++-ts-mode) "clangd") t)
+  (add-to-list 'eglot-server-programs '((rust-mode rust-ts-mode) "rust-analyzer") t))
+
+(use-package exec-path-from-shell
+  :if (memq system-type '(darwin gnu/linux))
+  :hook (after-init . exec-path-from-shell-initialize)
+  :custom
+  (exec-path-from-shell-variables '("PATH" "MANPATH" "GOPATH" "CARGO_HOME" "RUSTUP_HOME")))
+
+;; Project-aware navigation with built-in project.el.
+(use-package project
+  :ensure nil
+  :bind-keymap ("C-c p" . project-prefix-map)
+  :custom
+  (project-switch-commands
+   '((project-find-file "Find file")
+     (project-find-regexp "Find regexp")
+     (project-eshell "Eshell"))))
+
+;; -------------------------------------------------------------------
+;; Quality-of-life commands
+;; -------------------------------------------------------------------
+
+(defun toggle-fullscreen (&optional frame)
+  "Toggle fullscreen for FRAME.
+If FRAME is nil use the currently selected frame.  Preserve the
+previous frame state so we can restore it when toggling back."
+  (interactive)
+  (let* ((frame (or frame (selected-frame)))
+         (current (frame-parameter frame 'fullscreen)))
+    (set-frame-parameter
+     frame 'fullscreen
+     (if (eq current 'fullboth)
+         (prog1 (or (frame-parameter frame 'toggle-fullscreen--previous) nil)
+           (set-frame-parameter frame 'toggle-fullscreen--previous nil))
+       (set-frame-parameter frame 'toggle-fullscreen--previous current)
+       'fullboth))))
+(global-set-key (kbd "<f11>") #'toggle-fullscreen)
+
+;; Provide a simple way to jump back to this configuration file.
+(defun open-init-file ()
+  "Open this init file."
+  (interactive)
+  (find-file (expand-file-name "init.el" user-emacs-directory)))
+(global-set-key (kbd "C-c I") #'open-init-file)
+
+;; -------------------------------------------------------------------
+;; Final setup
+;; -------------------------------------------------------------------
+
+(message "Emacs is ready — happy hacking!")
+
+;;; init.el ends here

--- a/init.el
+++ b/init.el
@@ -61,8 +61,13 @@
 (setq display-line-numbers-type 'relative)
 (dolist (hook '(prog-mode-hook text-mode-hook conf-mode-hook))
   (add-hook hook #'display-line-numbers-mode))
-(dolist (mode '(vterm-mode-hook eshell-mode-hook shell-mode-hook term-mode-hook))
-  (add-hook mode (lambda () (display-line-numbers-mode 0))))
+(defun disable-display-line-numbers ()
+  "Turn off `display-line-numbers-mode'."
+  (display-line-numbers-mode 0))
+(dolist (mode '(eshell-mode-hook shell-mode-hook term-mode-hook))
+  (add-hook mode #'disable-display-line-numbers))
+(with-eval-after-load 'vterm
+  (add-hook 'vterm-mode-hook #'disable-display-line-numbers))
 
 (show-paren-mode 1)
 (when (fboundp 'pixel-scroll-precision-mode)
@@ -273,7 +278,7 @@ previous frame state so we can restore it when toggling back."
   "Open this init file."
   (interactive)
   (find-file (expand-file-name "init.el" user-emacs-directory)))
-(global-set-key (kbd "C-c I") #'open-init-file)
+(global-set-key (kbd "C-c C-e") #'open-init-file)
 
 ;; -------------------------------------------------------------------
 ;; Final setup

--- a/init.el
+++ b/init.el
@@ -13,6 +13,7 @@
 ;; -------------------------------------------------------------------
 
 (require 'package)
+(require 'cl-lib)
 (setq package-archives
       '(("gnu"    . "https://elpa.gnu.org/packages/")
         ("nongnu" . "https://elpa.nongnu.org/nongnu/")
@@ -229,13 +230,17 @@
 (use-package eglot
   :ensure nil
   :hook ((python-mode . eglot-ensure)
-         (go-mode     . eglot-ensure))
+         (go-mode . eglot-ensure)
+         (c-mode . eglot-ensure)
+         (c++-mode . eglot-ensure)
+         (c-ts-mode . eglot-ensure)
+         (c++-ts-mode . eglot-ensure)
+         (rust-mode . eglot-ensure)
+         (rust-ts-mode . eglot-ensure))
   :config
-  (dolist (hook '(c-mode-hook c++-mode-hook c-ts-mode-hook c++-ts-mode-hook
-                  rust-mode-hook rust-ts-mode-hook))
-    (add-hook hook #'eglot-ensure))
-  (add-to-list 'eglot-server-programs '((c-mode c++-mode c-ts-mode c++-ts-mode) "clangd") t)
-  (add-to-list 'eglot-server-programs '((rust-mode rust-ts-mode) "rust-analyzer") t))
+  (dolist (entry '(((c-mode c++-mode c-ts-mode c++-ts-mode) . ("clangd"))
+                   ((rust-mode rust-ts-mode) . ("rust-analyzer"))))
+    (cl-pushnew entry eglot-server-programs :test #'equal)))
 
 (use-package exec-path-from-shell
   :if (memq system-type '(darwin gnu/linux))


### PR DESCRIPTION
## Summary
- upgrade the Emacs configuration to use use-package with modern package archives and completion tooling
- refresh UI, editing, and project defaults to match 2025-era Emacs features
- document the updated setup and onboarding steps in the README
- expand built-in language tooling with clangd-powered C/C++ and rust-analyzer integration

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e618c1ff9c832bad298b77de3531db