### PR TITLE
Ensure devcontainer copies init.el

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Emacs Config Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/codespaces/default:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/emacs:1": {},
+    "ghcr.io/devcontainers/features/ripgrep:1": {}
+  },
+  "postCreateCommand": [
+    "bash",
+    "-lc",
+    "mkdir -p ~/.emacs.d && cp -f ${containerWorkspaceFolder}/init.el ~/.emacs.d/init.el && emacs --batch --eval '(message \"Emacs init loaded\")'"
+  ]
+}


### PR DESCRIPTION
## Summary
- keep using the GitHub Codespaces default image with Emacs and ripgrep features
- copy the repository's init.el into ~/.emacs.d during post-create so Emacs loads it
- continue verifying the init loads by running Emacs in batch mode

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e6306a3b60832bb36b9ffbe0af9ef0